### PR TITLE
Update URL for 14.04 ISO

### DIFF
--- a/build-ubuntu.sh
+++ b/build-ubuntu.sh
@@ -5,7 +5,7 @@ BUILD_OSTYPE="Ubuntu_64"
 
 # last 'LTS' version
 BOX="ubuntu-14.04-amd64"
-ISO_URL="http://releases.ubuntu.com/14.04/ubuntu-14.04-server-amd64.iso"
+ISO_URL="http://ubuntu-release.locaweb.com.br/14.04/ubuntu-14.04-server-amd64.iso"
 ISO_MD5="01545fa976c8367b4f0d59169ac4866c"
 
 ./build.sh ${BUILD_OSNAME} ${BUILD_OSTYPE} ${BOX} ${ISO_URL} ${ISO_MD5}


### PR DESCRIPTION
This way, it is again possible to create ISOs for Ubuntu 14.04 (not 14.04.1 or 14.04.2), as long as this mirror is live. This is however not excessively reliable.
