### PR TITLE
Support Ubuntu 14.04.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This script will:
  * curl
  * mkisofs/genisoimage
  * md5sum/md5
+ * xorriso
 
 ## Usage on OSX
 
@@ -29,6 +30,7 @@ This should do everything you need. If you don't have required package, install 
     brew install curl
     brew install cdrtools
     brew install coreutils
+    brew install xorriso
 
 ## Usage on Linux
 
@@ -43,6 +45,7 @@ This should do everything you need. If you don't have required package then:
     sudo apt-get install curl
     sudo apt-get install genisoimage
     sudo apt-get install coreutils
+    sudo apt-get install xorriso
 
 ## Usage on Windows (under cygwin/git shell)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This script will:
 
  * Oracle VM VirtualBox
  * Vagrant
- * 7zip
  * curl
  * mkisofs/genisoimage
  * md5sum/md5
@@ -26,7 +25,6 @@ or
 
 This should do everything you need. If you don't have required package, install [homebrew](http://mxcl.github.com/homebrew/), then:
 
-    brew install p7zip
     brew install curl
     brew install cdrtools
     brew install coreutils
@@ -41,7 +39,6 @@ or
 
 This should do everything you need. If you don't have required package then:
 
-    sudo apt-get install p7zip-full
     sudo apt-get install curl
     sudo apt-get install genisoimage
     sudo apt-get install coreutils
@@ -54,9 +51,8 @@ or
 
     ./build-ubuntu.sh
 
-Tested under Windows 7 with this tools:
+Currently untested under Windows.
 
- * [7zip](http://www.7-zip.org/)
  * [cpio](http://gnuwin32.sourceforge.net/packages/cpio.htm)
  * [mkisofs](http://sourceforge.net/projects/cdrtoolswin/)
  * [md5](http://www.fourmilab.ch/md5/)

--- a/build-ubuntu.sh
+++ b/build-ubuntu.sh
@@ -4,8 +4,8 @@ BUILD_OSNAME="ubuntu"
 BUILD_OSTYPE="Ubuntu_64"
 
 # last 'LTS' version
-BOX="ubuntu-14.04-amd64"
-ISO_URL="http://releases.ubuntu.com/14.04/ubuntu-14.04-server-amd64.iso"
-ISO_MD5="01545fa976c8367b4f0d59169ac4866c"
+BOX="ubuntu-14.04.2-amd64"
+ISO_URL="http://releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso"
+ISO_MD5="83aabd8dcf1e8f469f3c72fff2375195"
 
 ./build.sh ${BUILD_OSNAME} ${BUILD_OSTYPE} ${BOX} ${ISO_URL} ${ISO_MD5}

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ ISO_MD5=$5
 # make sure we have dependencies
 hash VBoxManage 2>/dev/null || { echo >&2 "ERROR: VBoxManage not found.  Aborting."; exit 1; }
 hash vagrant 2>/dev/null || { echo >&2 "ERROR: vagrant not found.  Aborting."; exit 1; }
-hash 7z 2>/dev/null || { echo >&2 "ERROR: 7z not found. Aborting."; exit 1; }
+hash osirrox 2>/dev/null || { echo >&2 "ERROR: osirrox not found. Aborting."; exit 1; }
 hash curl 2>/dev/null || { echo >&2 "ERROR: curl not found. Aborting."; exit 1; }
 
 VBOX_VERSION="$(VBoxManage --version)"
@@ -131,9 +131,8 @@ if [ ! -e "${FOLDER_ISO}/custom.iso" ]; then
 
   echo "Using osirrox"
   osirrox -indev "${ISO_FILENAME}" -extract / "${FOLDER_ISO_CUSTOM}"
-  # If that didn't work, you have to update p7zip
   if [ ! -e ${FOLDER_ISO_CUSTOM} ]; then
-    echo "Error with extracting the ISO file with your version of p7zip. Try updating to the latest version."
+    echo "Error with extracting the ISO file with your version of xorriso."
     exit 1
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -129,9 +129,8 @@ fi
 echo "Creating Custom ISO"
 if [ ! -e "${FOLDER_ISO}/custom.iso" ]; then
 
-  echo "Using 7zip"
-  7z x "${ISO_FILENAME}" -o"${FOLDER_ISO_CUSTOM}"
-
+  echo "Using osirrox"
+  osirrox -indev "${ISO_FILENAME}" -extract / "${FOLDER_ISO_CUSTOM}"
   # If that didn't work, you have to update p7zip
   if [ ! -e ${FOLDER_ISO_CUSTOM} ]; then
     echo "Error with extracting the ISO file with your version of p7zip. Try updating to the latest version."

--- a/build.sh
+++ b/build.sh
@@ -137,6 +137,9 @@ if [ ! -e "${FOLDER_ISO}/custom.iso" ]; then
     exit 1
   fi
 
+  echo "Making extracted files writable"
+  chmod -R +w "${FOLDER_ISO_CUSTOM}"
+
   # small @hack
   if [ "${BUILD_OSNAME}" = "ubuntu" ]; then
     mv "${FOLDER_ISO_CUSTOM}/install" "${FOLDER_ISO_CUSTOM}/install.amd"

--- a/ubuntu/preseed.cfg
+++ b/ubuntu/preseed.cfg
@@ -42,6 +42,7 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 d-i partman/mount_style select uuid
+d-i base-installer/kernel/image string linux-generic-lts-utopic
 
 ### Account setup
 d-i passwd/root-login boolean false


### PR DESCRIPTION
To switch to Ubuntu 14.04.2, one needs to change three things:
- the ISO URL (obvious)
- the preseed file (for more complicated reasons, the original one doesn't work)
- the extraction program: p7zip only supports URLs of 64 bytes (because it reads filenames off Joliet, and officially Joliet is limited to 64 bytes); to fix this problem, one needs an extractor that supports the Rock Ridge extension to the ISO format.
  I switched to xorriso, which worked for me on OS X and should work on Linux. However, it's not obvious this supports Windows. I've found some discussions by Googling, but not yet any other solution.
