### PR TITLE
Use proper HTTP redirector in mirror

### DIFF
--- a/debian/preseed.cfg
+++ b/debian/preseed.cfg
@@ -15,7 +15,7 @@ d-i hw-detect/load_firmware boolean true
 
 ### Mirror settings
 d-i mirror/country string manual
-d-i mirror/http/hostname string cdn.debian.net
+d-i mirror/http/hostname string httpredir.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 d-i mirror/suite string testing


### PR DESCRIPTION
cdn.debian.net is deprecated, see:
https://wiki.debian.org/DebianGeoMirror
